### PR TITLE
fixes a S3 307 temporary endpoint for newly created buckets

### DIFF
--- a/lib/npm_credentials.js
+++ b/lib/npm_credentials.js
@@ -13,7 +13,7 @@ module.exports = function (options) {
             if (err) {reject(err);}
             var token = obj.config.getCredentialsByURI(host).token;
             if (token) {
-                log.info("Found npm credentials ", JSON.stringify({host: host, token: token}));
+                log.info("Found npm credentials for ", host);
                 resolve(token);
             } else {
                 reject("npm credentials not found for " + host);

--- a/publish.js
+++ b/publish.js
@@ -28,7 +28,7 @@ function put(url, file_path) {
             'content-type': 'application/octet-stream',
             'content-length': fs.statSync(file_path).size
         };
-        var req = request.put({uri: url, headers: headers});
+        var req = request.put({uri: url, headers: headers, followAllRedirects: true});
         req.on('error', (err) => reject(err));
         req.on('response', function (res) {
             if (res.statusCode >= 200 && res.statusCode < 300) {


### PR DESCRIPTION
With newly created buckets, S3 requests may be redirected by AWS S3 service.
**request** npm module doesn't follow redirects by default with PUT verbs.
This PR forces request.put to follow redirects.
